### PR TITLE
Add GitHub Actions workflow for building and uploading Apache Cassandra TAR files

### DIFF
--- a/.github/workflows/qb-build-cassandra.yaml
+++ b/.github/workflows/qb-build-cassandra.yaml
@@ -43,13 +43,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create a New Tag
-        uses: nookyo/qubership-workflow-hub/actions/tag-action@main
+        uses: netcracker/qubership-workflow-hub/actions/tag-action@main
         with:
           ref: ${{ github.ref_name }}
           tag-name: ${{ inputs.tag }}
           force-create: ${{ inputs.forceCreate }}
           switch-to-tag: true
           create-release: true
+          skip-checkout: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Introduce a GitHub Actions workflow to automate the building of Apache Cassandra TAR files, including enhancements for asset uploads and tag creation. The workflow simplifies the release process and ensures only relevant files are uploaded.