### PR TITLE
Set fetch-depth to 0 for checkout step

### DIFF
--- a/.github/workflows/qb-build-cassandra.yaml
+++ b/.github/workflows/qb-build-cassandra.yaml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Create a New Tag
         uses: netcracker/qubership-workflow-hub/actions/tag-action@main


### PR DESCRIPTION
Ensure the checkout step retrieves the full history of the repository by setting the fetch-depth to 0.